### PR TITLE
Update jekyll.yml

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,7 +1,7 @@
 name: Jekyll site CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
修改了pull_request 为 pull_request_target TUT 

Error: Resource not accessible by integration. In some cases, the GitHub token used for actions triggered from `pull_request` events are read-only, which can cause this problem. Switching to the `pull_request_target` event typically resolves this issue.