### PR TITLE
Update map_info、map_info_child and map_info_int

### DIFF
--- a/_data/map_info.json
+++ b/_data/map_info.json
@@ -652,6 +652,11 @@
               "name": "王岚",
               "clas": 2,
               "desc": "zzd和zsd可开。"
+            },
+            {
+              "name": "余明",
+              "clas": 2,
+              "desc": null
             }
           ]
         },
@@ -662,6 +667,11 @@
               "name": "张欣",
               "clas": 2,
               "desc": "心理保健中心可以开药，张欣医生在儿少门诊。"
+            },
+            {
+              "name": "李阳",
+              "clas": 2,
+              "desc": null
             }
           ]
         },
@@ -670,7 +680,7 @@
           "doctor": [
             {
               "name": "乜欣红",
-              "clas": 2,
+              "clas": 3,
               "desc": null
             }
           ]
@@ -750,6 +760,10 @@
         {
           "title": "【更新】昆明成人ADHD就诊经历",
           "url": "https://mp.weixin.qq.com/s/z9z7P7iN5PYo0azde9wXvw"
+        },
+        {
+          "title": "昆明医科大学第一附属医院成人ASD就诊经历",
+          "url": "https://mp.weixin.qq.com/s/rWSENteOhnqzwf6ekum-Uw"
         }
       ]
     },
@@ -1041,7 +1055,7 @@
             {
               "name": "孙榕蔚",
               "clas": 2,
-              "desc": null
+              "desc": "可以开zzd，需要户口本复印件，建议提前带好身份证和户口本索引页＋个人页印在一张纸上的复印件"
             }
           ]
         },
@@ -1161,6 +1175,7 @@
       "location": [
         {
           "name": "浙江大学医学院附属第一医院 （余杭院区）（庆春院区）",
+          "desc": "国外确诊记录也可开药",
           "doctor": [
             {
               "name": "付广慧",
@@ -1207,6 +1222,11 @@
             {
               "name": "程芳",
               "clas": 1,
+              "desc": null
+            },
+            {
+              "name": "胡珍玉",
+              "clas": 3,
               "desc": null
             }
           ]
@@ -1265,6 +1285,7 @@
         },
         {
           "name": "温州医科大学附属康宁医院",
+          "desc": "有ADHD门诊",
           "doctor": [
             {
               "name": "于学力",
@@ -1275,6 +1296,19 @@
               "name": "叶敏捷",
               "clas": 2,
               "desc": null
+            },
+            {
+              "name": "李美花",
+              "clas": 3,
+              "desc": null
+            }
+          ]
+        },
+        {
+          "info_link": [
+            {
+              "title": "温州康宁医院ASD成人就诊经历：确诊了，然后呢？",
+              "url": "https://mp.weixin.qq.com/s/gJfci3l40C82rjNNuvYmYA"
             }
           ]
         },
@@ -1722,14 +1756,14 @@
     },
     {
       "name": "内蒙古",
-      "value": 0,
+      "value": 2,
       "location": [
         {
-          "name": null,
+          "name": "内蒙古自治区第三医院儿少心理医学中心",
           "doctor": [
             {
-              "name": null,
-              "clas": null,
+              "name": "景兰",
+              "clas": 2,
               "desc": null
             }
           ]
@@ -1980,6 +2014,11 @@
               "name": "林震",
               "clas": 2,
               "desc": "可讲普通话，可开zzd和Vyvanse，价格可谈。"
+            },
+            {
+              "name": "李靖国",
+              "clas": 2,
+              "desc": null
             }
           ]
         }

--- a/_data/map_info_child.json
+++ b/_data/map_info_child.json
@@ -94,14 +94,14 @@
     },
     {
       "name": "上海",
-      "value": 0,
+      "value": 3,
       "location": [
         {
-          "name": null,
+          "name": "上海新华医院",
           "doctor": [
             {
-              "name": null,
-              "clas": null,
+              "name": "张劲松",
+              "clas": 3,
               "desc": null
             }
           ]
@@ -174,7 +174,8 @@
       "value": 0,
       "location": [
         {
-          "name": null,
+          "name": "昆明市儿童医院（书林院区）",
+          "desc": "儿保科多动症专科或学习困难专病门诊可看ADHD，开药可以挂普通儿保",
           "doctor": [
             {
               "name": null,
@@ -270,6 +271,16 @@
               "desc": "可开zzd和tmxt，门诊挂号注意选儿童保健门诊 - 心理卫生门诊。"
             }
           ]
+        },
+        {
+          "name": "青岛大学附属医院儿保科",
+          "doctor": [
+            {
+              "name": "衣明纪",
+              "clas": 3,
+              "desc": "可确诊ADHD、ASD以及抽动症"
+            }
+          ]
         }
       ]
     },
@@ -277,6 +288,16 @@
       "name": "江苏",
       "value": 2,
       "location": [
+        {
+          "name": "南京脑科儿童心理卫生中心",
+          "doctor": [
+            {
+              "name": "焦公凯",
+              "clas": 3,
+              "desc": null
+            }
+          ]
+        },
         {
           "name": "南京市儿童医院",
           "desc": "<br>学习困难门诊/心理行为门诊",
@@ -351,11 +372,12 @@
         },
         {
           "name": "武汉儿童医院",
+          "desc": "康复科有学习困难多动症门诊",
           "doctor": [
             {
-              "name": null,
-              "clas": null,
-              "desc": null
+              "name": "林俊",
+              "clas": 3,
+              "desc": "康复专家门诊"
             }
           ]
         }
@@ -625,14 +647,14 @@
     },
     {
       "name": "内蒙古",
-      "value": 0,
+      "value": 2,
       "location": [
         {
-          "name": null,
+          "name": "内蒙古自治区第三医院儿少心理医学中心",
           "doctor": [
             {
-              "name": null,
-              "clas": null,
+              "name": "任瑞",
+              "clas": 2,
               "desc": null
             }
           ]

--- a/_data/map_info_int.json
+++ b/_data/map_info_int.json
@@ -57,6 +57,10 @@
         {
           "title": "【攻略】ADHDer如何携带自用药物入境美国和开药",
           "url": "https://mp.weixin.qq.com/s/jqit4D3dLmkvp7l6vnP-Nw"
+        },
+        {
+          "title": "美国成人ASD就诊记录",
+          "url": "https://mp.weixin.qq.com/s/-yRGEY7aOJ8EbJ4RqRDV5A"
         }
       ]
     },
@@ -147,6 +151,10 @@
         {
           "title": "英国成人ADHD非自费确诊经历分享",
           "url": "https://mp.weixin.qq.com/s/_tJAyTKyNACzC1kO-smc8w"
+        },
+        {
+          "title": "英国成人ADHD确诊经历：等待了24年的确诊",
+          "url": "https://mp.weixin.qq.com/s/yuv4-qogCozKMdsnYWUNsw"
         }
       ]
     },


### PR DESCRIPTION
儿童版地图：
1.	增加南脑焦公凯
2.	增加昆明市儿童医院
3.	增加内蒙古第三医院儿少心理医学中心任瑞
4.	增加青岛大学附属医院儿保科衣纪明
5.	增加武汉儿童医院描述和医生林俊
6.	增加上海市新华医院张劲松

成人版
1.	浙一医院添加描述“国外确诊记录可以开药”
2.	增加内蒙古第三医院儿少心理医学中心景兰
3.	河北医科大学乜欣红分类2→3
4.	补充威海市立医院孙榕蔚医生的描述
5.	增加香港中建医务李靖国
6.	增加河北医科大学第一医院余明
7.	增加宁波康宁胡珍玉
8.	增加河北省第六人民医院李阳
9.	增加温州康宁医院描述和医生李美花、文章链接
10.	增加昆明医科大学第一附属医院文章链接

国际版：
增加英国和美国文章链接